### PR TITLE
Improve AppArmor profile

### DIFF
--- a/apparmor.profile.dnscrypt-proxy
+++ b/apparmor.profile.dnscrypt-proxy
@@ -1,4 +1,4 @@
-# Last Modified: Sat Jul 6 02:21:04 2013
+# Last Modified: Fri Oct 25 15:33:29 2013
 
 #include <tunables/global>
 

--- a/apparmor.profile.dnscrypt-proxy
+++ b/apparmor.profile.dnscrypt-proxy
@@ -1,22 +1,19 @@
-# Last Modified: Sat Jul  6 02:21:04 2013
+# Last Modified: Sat Jul 6 02:21:04 2013
 
 #include <tunables/global>
 
-/usr/local/sbin/dnscrypt-proxy {
+/usr/sbin/dnscrypt-proxy {
 
-  network inet  stream,
+  network inet stream,
   network inet6 stream,
-  network inet  dgram,
+  network inet dgram,
   network inet6 dgram,
 
-  capability block_suspend,
   capability net_admin,
   capability net_bind_service,
   capability setgid,
   capability setuid,
   capability sys_chroot,
-
-  /usr/local/lib/libsodium.so* mr,
 
   /bin/false r,
   /dev/null rw,
@@ -25,18 +22,25 @@
   /etc/localtime r,
   /etc/nsswitch.conf r,
   /etc/passwd r,
-  
-  /lib/*-linux-gnu*/libc-*.so mr,
-  /lib/*-linux-gnu*/libm-*.so mr,
-  /lib/*-linux-gnu*/libnsl-*.so mr,
-  /lib/*-linux-gnu*/libnss_compat-*.so mr,
-  /lib/*-linux-gnu*/libnss_files-*.so mr,
-  /lib/*-linux-gnu*/libnss_nis-*.so mr,
 
+  /lib/@{multiarch}/libc-*.so mr,
+  /lib/@{multiarch}/libm-*.so mr,
+  /lib/@{multiarch}/libnsl-*.so mr,
+  /lib/@{multiarch}/libnss_compat-*.so mr,
+  /lib/@{multiarch}/libnss_files-*.so mr,
+  /lib/@{multiarch}/libnss_nis-*.so mr,
+  /lib/@{multiarch}/libpthread-*.so mr,
+  /lib/@{multiarch}/librt-*.so mr,
+  /lib/@{multiarch}/libsodium-*.so mr,
+
+# In case of custom libsodium installation
   /usr/lib/libsodium.so* mr,
   /usr/local/lib/libsodium.so* mr,
 
 # Plugins
   /usr/lib/libdns.so* mr,
+
+# Reasonable pidfile location - tweak this if you prefer a different one
+  /run/dnscrypt-proxy.pid rw,
 
 }


### PR DESCRIPTION
- Use @{multiarch} tunable instead of *-linux-gnu* - they are the same on my system, but using the global tunable is more robust/portable
- Drop block_suspend capability because it requires Linux >= 3.5 and does not seem to be needed (as of my testing)
- Allow access to libpthread and librt, extensive testing indicates it is sometimes needed (libsodium multithreading?)
- Allow access to libsodium if it's installed in the system default path with multiarch support instead of just /usr/lib/ and /usr/local/lib
